### PR TITLE
Patch weo

### DIFF
--- a/bblocks/import_tools/imf.py
+++ b/bblocks/import_tools/imf.py
@@ -58,7 +58,7 @@ class WorldEconomicOutlook(ImportData):
 
         # If year and release are not specified, get the latest version
         if self.year is None and self.release is None:
-            version = None # set version to None to get the latest version, after need to set the year and release in the object
+            version = None  # set version to None to get the latest version, after need to set the year and release in the object
 
         # if year and release are specified, use them
         else:


### PR DESCRIPTION
Patches a fix so that the latest expected version is rolled back if no data is available
No breaking changes included

___

This pull request includes changes to the `__load_data` method in the `bblocks/import_tools/imf.py` file to improve the handling of version fetching and error handling. The most important changes include setting the version to `None` for fetching the latest version, adding a check for valid release values, and updating the fetched version handling.

Improvements to version handling and error checking:

* [`bblocks/import_tools/imf.py`](diffhunk://#diff-a4ab37ba8d6e384d0f5aa69958c349228bbc1294678a4e11d25dd046fd550d6fL61-R74): Set `version` to `None` to get the latest version if year and release are not specified. Added a check to ensure that the release value is either 1 (April) or 2 (October), raising a `ValueError` if it is not.
* [`bblocks/import_tools/imf.py`](diffhunk://#diff-a4ab37ba8d6e384d0f5aa69958c349228bbc1294678a4e11d25dd046fd550d6fL81-R95): Updated fetched version handling to set the year and release based on the fetched version when no version is specified.